### PR TITLE
Fix issue #2 - add support for specifying proxy source IP binding

### DIFF
--- a/PostgresDataMasker.cs
+++ b/PostgresDataMasker.cs
@@ -80,6 +80,12 @@ namespace PgMaskingProxy
             var j = JObject.Parse(File.ReadAllText("config.json"));
 
             int proxyPort = (int)j["proxy_port"];
+            string proxySourceIp = (string)j["proxy_source_ip"];
+
+            if(String.IsNullOrEmpty(proxySourceIp))
+            {
+              proxySourceIp = "127.0.0.1";
+            }
 
             var dbDetails = (JObject)j["db_connection_details"];
             string dbIp = (string)dbDetails["ip"];
@@ -91,7 +97,7 @@ namespace PgMaskingProxy
             Console.WriteLine($"\tProxy Port: {proxyPort}");
             Console.WriteLine($"\tDatabase Details: {user}@{dbIp}:{dbPort}/{db}");
             _tcpProxy = new TcpProxy(_pgStateMachine.ProcessBuffer, _pgStateMachine.SetStateToInitial);
-            _tcpProxy.Start(new IPEndPoint(IPAddress.Parse("127.0.0.1"), proxyPort), new IPEndPoint(IPAddress.Parse(dbIp), dbPort));
+            _tcpProxy.Start(new IPEndPoint(IPAddress.Parse(proxySourceIp), proxyPort), new IPEndPoint(IPAddress.Parse(dbIp), dbPort));
         }
 
         private Func<string,string> getMaskingFunction(uint tableOid, uint dataTypeOid, string columnName)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The configuration can be found in the config.json file in the root directory of 
 | Config Variable | Description |
 | ----------------|-----------------|
 |proxy_port|Local port on which Proxy will listen for client connections|
+|proxy_source_ip|Local IP address on which Proxy will listen for client connections|
 |db_connection_details| Connection details of the Postgres Database.  See the config.json for a list of required fields.|
 |masking_options| Details for how you want to mask your data.  Includes information on how to handle primary and foreign keys, how to mask based on column names or data types.  See below for a more detailed description|
 

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
 {
     "_comment": "Default Configuration supports automatic masking of most data types.  Currently the data types that are not automatically masked are: box, bytea, cidr, circle, interval, line, lseg, path, point, polygon, tsquery, tsvector,",
     "proxy_port":20000,
+    "proxy_source_ip": "127.0.0.1",
     "db_connection_details": {
         "port": 15432,
         "ip": "127.0.0.1",


### PR DESCRIPTION
Addresses: https://github.com/TonicAI/masquerade/issues/2

Adds support for a new config option, where you can set which IP you would like the proxy to be bound to on a host machine. This allows dockerization of this application to be possible by using the docker set up described in #2 along with a revised start.sh script containing:

```shell
#!/bin/bash
POSTGRES_IP=`getent hosts postgres | awk '{ print $1 }'`
SOURCE_IP=`getent hosts | grep 172 | awk '{ print $1 }'`
sed 's/POSTGRES_IP/'"$POSTGRES_IP"'/g; s/SOURCE_IP/'"$SOURCE_IP"'/g' config.sample.json > config.json
dotnet run
```