### PR TITLE
Allow multiple proxy connections

### DIFF
--- a/TcpProxy.cs
+++ b/TcpProxy.cs
@@ -10,7 +10,6 @@ namespace PgMaskingProxy
     {
         private readonly Func<byte[],int, MemoryStream> _processBytesReceivedFromDb;
         private readonly Socket _clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-        private Socket _dbSocket;
         private bool _inProcessOfNegotiatingSSL = false;
         Action _resetStatemachine;
         public TcpProxy(Func<byte[],int, MemoryStream> processBytesReceivedFromDb, Action resetStateMachine)
@@ -28,15 +27,13 @@ namespace PgMaskingProxy
             while(true)
             {
                 var source = _clientSocket.Accept();
-                if(_dbSocket!=null)
-                {
-                    _dbSocket.Close();
-                }
-                _dbSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                _dbSocket.Connect(remote);
-                var state = new State(source, _dbSocket);
+                Console.WriteLine("Got new connection");
+                Socket dbSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                Console.WriteLine("connecting to new socket");
+                dbSocket.Connect(remote);
+                var state = new State(source, dbSocket);
                 source.BeginReceive(state.ClientBuffer, 0, state.ClientBuffer.Length, 0, OnDataReceiveFromClient, state);
-                _dbSocket.BeginReceive(state.DatabaseBuffer, 0, state.DatabaseBuffer.Length, SocketFlags.None, OnDataReceiveFromDb, state);
+                dbSocket.BeginReceive(state.DatabaseBuffer, 0, state.DatabaseBuffer.Length, SocketFlags.None, OnDataReceiveFromDb, state);
             }
         }
 


### PR DESCRIPTION
Had issues using this with both `pgAdmin`  and `psql`. When querying, it always returned a disconnection error.
When performing a deeper analysis noticed that previous connections were being closed upon receiving new connections. This PR fixes that limitation creating a local connection when a new one is received by `masquerade`